### PR TITLE
fix bug in parse_primary and add support for parsing return statements

### DIFF
--- a/src/lib/ast.cc
+++ b/src/lib/ast.cc
@@ -24,6 +24,12 @@ get_data_type(DataType dt) {
 }
 
 void
+ReturnStmt::print() {
+  printf("%s ", this->token.literal.c_str());
+  this->ret_val->print();
+}
+
+void
 ExpressionStatement::print() {
   if (!this->expr) {
     printf("null expr\n");

--- a/src/lib/ast.hh
+++ b/src/lib/ast.hh
@@ -148,6 +148,21 @@ class LetStmt : public Statement {
     void print() override;
 };
 
+// Statement node for return statements
+// "return x + 5;"
+class ReturnStmt : public Statement {
+  public:
+    token_t token;
+    std::unique_ptr<Expression> ret_val; // return value of the function
+    
+    ReturnStmt(
+      token_t token,
+      std::unique_ptr<Expression> ret_val
+    ) : token(token), ret_val(std::move(ret_val)) {}
+    void print() override;
+};
+
+// Class for function prototypes
 class Prototype {
   public:
   std::string name;

--- a/src/lib/parser.cc
+++ b/src/lib/parser.cc
@@ -142,6 +142,18 @@ Parser::parse_float() {
   return rv;
 }
 
+// Parse return statements from a function body
+// "return 0;"
+std::unique_ptr<Statement>
+Parser::parse_return_statement() {
+  token_t return_tok = this->current_token;
+  this->next_token(); // eat return token
+                      
+  auto return_val = this->parse_expression_interior(); // get the expression it is returning
+  this->next_token(); // eat the ';'
+  return std::make_unique<ReturnStmt>(return_tok, std::move(return_val));
+}
+
 // Parse a function definition
 // functions are required to be defined where they are declared,
 // so when we parse the prototype, the rest of the definition must follow
@@ -231,6 +243,13 @@ Parser::parse_function_defn() {
           func_body.push_back(std::move(stmt));
           this->next_token();
           break;
+        case TOK_RETURN:
+          // parse return statements
+          printf("retur token: ||%s||\n", this->current_token.literal.c_str());
+          stmt = this->parse_return_statement();
+          func_body.push_back(std::move(stmt));
+          while (this->current_token.type != TOK_RBRACE) this->next_token();
+          break;
         default:
           printf("default token: ||%s||\n", this->current_token.literal.c_str());
           stmt = this->parse_expression_statement();
@@ -261,6 +280,9 @@ Parser::parse_primary() {
     case TOK_INT:
       printf("matched %s\n", this->current_token.literal.c_str());
       return this->parse_integer();
+    case TOK_FLOAT:
+      printf("matched %s\n", this->current_token.literal.c_str());
+      return this->parse_float();
     case TOK_IDENT:
       printf("matched %s\n", this->current_token.literal.c_str());
       return this->parse_identifier();
@@ -268,7 +290,7 @@ Parser::parse_primary() {
       printf("matched %s\n", this->current_token.literal.c_str());
       return this->parse_parentheses_expr();
     default:
-      printf("primary nul\n");
+      printf("primary null\n");
       return nullptr;
   }
 }

--- a/src/lib/parser.hh
+++ b/src/lib/parser.hh
@@ -28,6 +28,7 @@ public:
   // Parsing functions
   std::unique_ptr<Program> parse_program();                         // parse the top level program
   std::unique_ptr<Statement> parse_let_statement();                 // parse let statements
+  std::unique_ptr<Statement> parse_return_statement();              // parse return statements
   std::unique_ptr<Statement> parse_function_defn();                 // parse function prototypes
   std::unique_ptr<Expression> parse_integer();                      // parse an integer literal
   std::unique_ptr<Expression> parse_float();                        // parse floating point literal

--- a/src/thunderbird.cc
+++ b/src/thunderbird.cc
@@ -44,12 +44,13 @@ main(int argc, char** argv) {
 bool
 test_let() {
   std::string input = 
-    "let int val = 5;\n"
-    "define int add () {}\n"
     "entry int func1() {\n"
     "  let int x = 0;\n"
     "  x = y + z;\n"
-    "}\n";
+    "  return x+2;\n"
+    "  let int test = 0;\n"
+    "}\n"
+    "let float test = 0.0;\n";
 
   printf("input:\n%s\n\n", input.c_str());
   Parser *parser = new Parser(input);


### PR DESCRIPTION
In parse_primary(), we did not have a case for TOK_FLOAT, so it would not use the built in function to parse a float literal. This is now added and works

Function bodies now can have return statements. Once a return statement is read, it simply eats the rest of the function body after that and does not evaluate it at all.

TODO: require all functions to have a return statement at some point