### PR TITLE
add line num in lexer and tokens and print it out on some errors

### DIFF
--- a/src/lib/lexer.cc
+++ b/src/lib/lexer.cc
@@ -4,6 +4,7 @@
 
 // Constructor
 Lexer::Lexer(std::string input) {
+  this->line_num = 1;
   this->input = input;
   this->read_char();
 
@@ -46,46 +47,57 @@ Lexer::next_token() {
         this->read_char();
         tok.type = TOK_EQUALTO;
         tok.literal = "==";
+        tok.line_num = this->line_num;
       } else {
         tok.type = TOK_EQUALS;
         tok.literal = std::string(1, this->cur_char);
+        tok.line_num = this->line_num;
       }
       break;
     case ';':
       tok.type = TOK_SEMICOLON;
       tok.literal = std::string(1, this->cur_char);
+      tok.line_num = this->line_num;
       break;
     case '(':
       tok.type = TOK_LPAREN;
       tok.literal = std::string(1, this->cur_char);
+      tok.line_num = this->line_num;
       break;
     case ')':
       tok.type = TOK_RPAREN;
       tok.literal = std::string(1, this->cur_char);
+      tok.line_num = this->line_num;
       break;
     case '{':
       tok.type = TOK_LBRACE;
       tok.literal = std::string(1, this->cur_char);
+      tok.line_num = this->line_num;
       break;
     case '}':
       tok.type = TOK_RBRACE;
       tok.literal = std::string(1, this->cur_char);
+      tok.line_num = this->line_num;
       break;
     case '[':
       tok.type = TOK_LBRACKET;
       tok.literal = std::string(1, this->cur_char);
+      tok.line_num = this->line_num;
       break;
     case ']':
       tok.type = TOK_RBRACKET;
       tok.literal = std::string(1, this->cur_char);
+      tok.line_num = this->line_num;
       break;
     case ',':
       tok.type = TOK_COMMA;
       tok.literal = std::string(1, this->cur_char);
+      tok.line_num = this->line_num;
       break;
     case '+':
       tok.type = TOK_PLUS;
       tok.literal = std::string(1, this->cur_char);
+      tok.line_num = this->line_num;
       break;
     case '<':
       // future: account for '<<' for bitshifting
@@ -93,9 +105,11 @@ Lexer::next_token() {
         this->read_char();
         tok.type = TOK_LTEQUALTO;
         tok.literal = "<=";
+        tok.line_num = this->line_num;
       } else {
         tok.type = TOK_LT;
         tok.literal = std::string(1, this->cur_char);
+        tok.line_num = this->line_num;
       }
       break;
     case '>':
@@ -104,9 +118,11 @@ Lexer::next_token() {
         this->read_char();
         tok.type = TOK_GTEQUALTO;
         tok.literal = ">=";
+        tok.line_num = this->line_num;
       } else {
         tok.type = TOK_GT;
         tok.literal = std::string(1, this->cur_char);
+        tok.line_num = this->line_num;
       }
       break;
     case '!':
@@ -114,40 +130,49 @@ Lexer::next_token() {
         this->read_char();
         tok.type = TOK_NOTEQUALTO;
         tok.literal = "!=";
+        tok.line_num = this->line_num;
       } else {
         tok.type = TOK_BANG;
         tok.literal = std::string(1, this->cur_char);
+        tok.line_num = this->line_num;
       }
       break;
     case '*':
       tok.type = TOK_ASTERISK;
       tok.literal = std::string(1, this->cur_char);
+      tok.line_num = this->line_num;
       break;
     case '/':
       tok.type = TOK_SLASH;
       tok.literal = std::string(1, this->cur_char);
+      tok.line_num = this->line_num;
       break;
     case '-':
       tok.type = TOK_MINUS;
       tok.literal = std::string(1, this->cur_char);
+      tok.line_num = this->line_num;
       break;
     case '\0':
       tok.type = TOK_EOF;
       tok.literal = "";
+      tok.line_num = this->line_num;
       break;
     default:
       if (isalpha(this->cur_char) != 0) {
         tok.literal = this->read_identifier();
         tok.type = this->lookup_identifier(tok.literal);
+        tok.line_num = this->line_num;
         return tok; // we return early here because read_identifier() advances this->cur_char repeatedly
       } else if (isdigit(this->cur_char) != 0) {
         // for now assume all number are ints
         // tok.type = TOK_INT;
         tok = this->read_number();
+        tok.line_num = this->line_num;
         return tok;
       } else {
         tok.type = TOK_ILLEGAL;
         tok.literal = std::string(1, this->cur_char);
+        tok.line_num = this->line_num;
       }
   };
 
@@ -226,6 +251,8 @@ Lexer::skip_whitespace() {
     this->cur_char == '\t' ||
     this->cur_char == '\r'
   ) {
+    if (this->cur_char == '\n')
+      this->line_num++;
     this->read_char();
   }
 }

--- a/src/lib/lexer.hh
+++ b/src/lib/lexer.hh
@@ -13,6 +13,7 @@ class Lexer {
 
   public:
     std::string input; // the source code input
+    int line_num;      // the line number that we are currently on
     int position;      // the current position in the input
     int read_position; // the current reading position in input (after current char)
     char cur_char;     // current char under examination

--- a/src/lib/parser.cc
+++ b/src/lib/parser.cc
@@ -102,14 +102,14 @@ Parser::parse_let_statement() {
     if (this->peek_token.type == TOK_EQUALS) {
       // read identifier then an equals -> assume they forgot to put type spec
       // because they forgot it, we have one less token, and we are already at the variable identifier
-      printf("parse_let: error: missing type specifier for '%s'\n", type_spec.literal.c_str());
+      printf("parse_let: error on line %d: missing type specifier for '%s'\n", type_spec.line_num, type_spec.literal.c_str());
       ident_tok = type_spec;
 
     } else if (this->peek_token.type == TOK_IDENT) {
       // read identifier then another identifier, assume they mispelled type spec
       // we should still have correct number of tokens, so we can continue
       // keep the data type as VOID for now
-      printf("parse_let: error: misspelled type specifier '%s'\n", type_spec.literal.c_str());
+      printf("parse_let: error on line %d: misspelled type specifier '%s'\n", type_spec.line_num, type_spec.literal.c_str());
 
       printf("parse_let: should be eating type specifier\n");
       this->next_token(); // eat the type specifier
@@ -302,10 +302,10 @@ Parser::parse_function_defn() {
       printf("parse_func: should be eating type spec\n");
       this->next_token(); // eat the type specifer
 
-      printf("parse_func_defn: error: mispelled return type specifier '%s'\n", tok.literal.c_str());
+      printf("parse_func_defn: error on line %d: mispelled return type specifier '%s'\n", tok.line_num, tok.literal.c_str());
       ident = this->current_token;
       if (ident.type != TOK_IDENT) {
-        printf("parse_func_defn: error: unexpected token '%s'. Expected 'IDENT'\n", ident.literal.c_str());
+        printf("parse_func_defn: error on line %d: unexpected token '%s'. Expected 'IDENT'\n", tok.line_num, ident.literal.c_str());
         return nullptr;
       }
       proto_name = ident.literal;

--- a/src/lib/token.hh
+++ b/src/lib/token.hh
@@ -88,6 +88,7 @@ enum DataType {
 
 // Structure for tokens that the lexer creates
 typedef struct Token {
+  int line_num;        // the line number of the source code the token exists in
   TokenType type;      // the actual token enum
   std::string literal; // the literal of the token -- identifier string or the symbol that it represents
 } token_t;

--- a/tests/test0.tb
+++ b/tests/test0.tb
@@ -1,4 +1,4 @@
-define main() {
-  let int x = 0;
+define inty main() {
+  let x = 0;
   return x;
 }


### PR DESCRIPTION
The token_t type now contains a field containing the line number that the token is read on.

The way that this is calculated is that every time the lexer encounters a '\n' it increments a line number field that the lexer also contains.

On certain errors in parsing a function definition and variable definition, it will print out the line number that the error is on.