### PR TITLE
parser now uses the token stream output from lexer as its input

### DIFF
--- a/src/lib/compiler.cc
+++ b/src/lib/compiler.cc
@@ -7,7 +7,6 @@
 Compiler::Compiler(std::string input_text) {
   this->input = input_text;
   this->lexer = new Lexer(this->input);
-  this->parser = new Parser(this->input);
 }
 
 // Destructor for the compiler
@@ -15,4 +14,17 @@ Compiler::~Compiler() {
   delete this->parser;
   delete this->lexer;
 
+}
+
+void
+Compiler::test_lexer() {
+
+}
+
+void
+Compiler::test_parser() {
+  this->lexer->tokenize_input();
+  std::vector<token_t> tokens = this->lexer->tokens;
+  this->parser = new Parser(tokens);
+  this->parser->parse_program();
 }

--- a/src/lib/compiler.hh
+++ b/src/lib/compiler.hh
@@ -11,14 +11,19 @@
 
 class Compiler {
   public:
+    // Member Variables
     std::string input; // this will eventually change to list of files or whatever module system is
     SymbolTable symbol_table;
 
     Lexer *lexer;
     Parser *parser;
   
+    // Member Functions
     Compiler(std::string source_code);
     ~Compiler();
+
+    void test_lexer();
+    void test_parser(); 
 };
 
 #endif /* COMPILER */

--- a/src/lib/lexer.cc
+++ b/src/lib/lexer.cc
@@ -172,12 +172,14 @@ Lexer::next_token() {
         tok.literal = this->read_identifier();
         tok.type = this->lookup_identifier(tok.literal);
         tok.line_num = this->line_num;
+        this->tokens.push_back(tok);
         return tok; // we return early here because read_identifier() advances this->cur_char repeatedly
       } else if (isdigit(this->cur_char) != 0) {
         // for now assume all number are ints
         // tok.type = TOK_INT;
         tok = this->read_number();
         tok.line_num = this->line_num;
+        this->tokens.push_back(tok);
         return tok;
       } else {
         tok.type = TOK_ILLEGAL;

--- a/src/lib/parser.cc
+++ b/src/lib/parser.cc
@@ -9,8 +9,9 @@
 #include <type_traits>
 
 // Constructor
-Parser::Parser(std::string input) {
-  this->lex = new Lexer(input);
+Parser::Parser(std::vector<token_t> token_stream) {
+  this->token_stream = token_stream;
+  this->current_position = 0;
   this->has_entry = false;
 
   // Initialize the token values
@@ -41,7 +42,6 @@ Parser::Parser(std::string input) {
 
 // Destructor -- delete the lexical analyzer
 Parser::~Parser() {
-  delete this->lex;
 }
 
 // Advance the current token to the next one
@@ -49,7 +49,10 @@ void
 Parser::next_token() {
   printf("next_token: eating '%s'\n", this->current_token.literal.c_str());
   this->current_token = this->peek_token;
-  this->peek_token = this->lex->next_token();
+  if (this->current_position < this->token_stream.size())
+    this->peek_token = this->token_stream[this->current_position];
+  this->current_position++;
+  // this->peek_token = this->lex->next_token();
 }
 
 // Parse let statements
@@ -677,7 +680,7 @@ Parser::parse_program() {
   auto program = std::make_unique<Program>();
 
   // main loop
-  while(this->current_token.type != TOK_EOF) {
+  while (this->current_token.type != TOK_EOF) {
     std::unique_ptr<Statement> stmt;
     switch(this->current_token.type) {
       case TOK_LET: // Top-level variable declarations;
@@ -716,7 +719,6 @@ Parser::parse_program() {
         break;
     }
   }
-  printf("\n -- Input --\n%s\n", this->lex->input.c_str());
 
   printf(" -- Program --\n");
   program->print();

--- a/src/lib/parser.hh
+++ b/src/lib/parser.hh
@@ -19,11 +19,14 @@
 // the Abstract Syntax Tree
 class Parser {
 public:
-  Parser(std::string input);  // constructor -- uses string parameter to initialize a lexer
+  Parser(std::vector<token_t> token_stream);  // constructor -- uses string parameter to initialize a lexer
   ~Parser();                  // destructor -- deletes the lexer that it created
+
   void next_token();          // eats current token and advances the peek and current tokens
   int get_token_precedence(); // gets the precedence for the current token
   bool has_entry;             // true if there is an entry point false otherwise
+  std::vector <token_t> token_stream; // token stream to parse
+  size_t current_position;               // the current position we are at in the token stream
 
   // Parsing functions
   std::unique_ptr<Program> parse_program();                         // parse the top level program
@@ -46,7 +49,6 @@ public:
   std::unique_ptr<Expression>parse_primary(); // parse members of an expression
   std::unique_ptr<Expression>parse_expression_interior(); // parses expression that are not top level
 
-  Lexer *lex;            // scanner that the parser gets the token stream from
   token_t current_token; // the current token that the parser is 'looking at'
   token_t peek_token;    // the next token that the parser would be looking at
   std::map <int, int> operator_precedences;

--- a/src/thunderbird.cc
+++ b/src/thunderbird.cc
@@ -11,7 +11,6 @@
 #include "parser.hh"
 
 bool test_lexer();
-bool test_let();
 std::string read_file(char *file_name);
 
 
@@ -20,12 +19,12 @@ main(int argc, char** argv) {
   std::string file_name;
 
   if (argc < 2) {
-//    if (test_lexer() == true) {
-//      printf("-- all tests passed --\n");
-//    }
-    if (test_let() == true) {
-      printf("let statement passed\n");
-    }
+    std::string input = read_file((char*)"tests/test0.tb");
+    Compiler *compiler = new Compiler(input);
+
+    compiler->test_parser();
+
+    delete compiler;
   } else {
     // Read the file specified through the command line argument
     // ignore all other args for now
@@ -41,18 +40,6 @@ main(int argc, char** argv) {
 
   return 0;
 }
-
-bool
-test_let() {
-  std::string input = read_file((char*)"tests/test0.tb");
-  Compiler *compiler = new Compiler(input);
-
-  compiler->parser->parse_program();
-
-  delete compiler;
-  return true;
-}
-
 
 // read input from file
 std::string


### PR DESCRIPTION
The lexer now creates a token stream output, and it is passed into the parser as input. The parser then runs through this instead of tokenizing on the fly.