### PR TITLE
added error handler class and parser can now use it

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 CC=g++
 CFLAGS=-g -Wall -Isrc/lib
 EXECS=bin/thunder
-LIB=lib/compiler.a lib/lexer.a lib/parser.a lib/ast.a
+LIB=lib/compiler.a lib/lexer.a lib/parser.a lib/ast.a lib/errorhandler.a
 
 all: $(EXECS)
 
@@ -20,6 +20,13 @@ lib/compiler.a: obj/compiler.o
 	ranlib $@
 
 obj/compiler.o: src/lib/compiler.cc
+	$(CC) $(CFLAGS) -c $< -o $@
+
+lib/errorhandler.a: obj/errorhandler.o
+	ar ru $@ $<
+	ranlib $@
+
+obj/errorhandler.o: src/lib/errorhandler.cc
 	$(CC) $(CFLAGS) -c $< -o $@
 
 lib/lexer.a: obj/lexer.o

--- a/src/lib/compiler.cc
+++ b/src/lib/compiler.cc
@@ -1,3 +1,5 @@
+#include "errorhandler.hh"
+#include "symboltable.hh"
 #include "token.hh"
 #include "lexer.hh"
 #include "parser.hh"
@@ -7,13 +9,17 @@
 Compiler::Compiler(std::string input_text) {
   this->input = input_text;
   this->lexer = new Lexer(this->input);
+
+  this->symbol_table = new SymbolTable();
+  this->error_handler = new ErrorHandler();
 }
 
 // Destructor for the compiler
 Compiler::~Compiler() {
   delete this->parser;
   delete this->lexer;
-
+  delete this->symbol_table;
+  delete this->error_handler;
 }
 
 void
@@ -27,5 +33,8 @@ Compiler::test_parser() {
   this->lexer->tokenize_input();
   std::vector<token_t> tokens = this->lexer->tokens;
   this->parser = new Parser(tokens);
+  this->parser->error_handler = this->error_handler;
   this->parser->parse_program();
+
+  this->error_handler->print_errors();
 }

--- a/src/lib/compiler.hh
+++ b/src/lib/compiler.hh
@@ -8,12 +8,14 @@
 #include "lexer.hh"
 #include "parser.hh"
 #include "symboltable.hh"
+#include "errorhandler.hh"
 
 class Compiler {
   public:
     // Member Variables
     std::string input; // this will eventually change to list of files or whatever module system is
-    SymbolTable symbol_table;
+    SymbolTable *symbol_table;
+    ErrorHandler *error_handler;
 
     Lexer *lexer;
     Parser *parser;

--- a/src/lib/errorhandler.cc
+++ b/src/lib/errorhandler.cc
@@ -1,0 +1,20 @@
+#include "errorhandler.hh"
+
+// Prints out all the errors that the compiler caught
+void
+ErrorHandler::print_errors() {
+  for (size_t i = 0; i < this->error_log.size(); i++) {
+    printf("Line %lu: %s\n", this->error_log[i].line_num, this->error_log[i].message.c_str());
+  }
+
+  if (this->error_log.size() == 0) {
+    printf("no errors :)\n");
+  }
+}
+
+// Creates a new error and appends it to the error log
+void
+ErrorHandler::new_error(size_t line_num, std::string message) {
+  ErrorLogEntry err = ErrorLogEntry(line_num, message);
+  this->error_log.push_back(err);
+}

--- a/src/lib/errorhandler.hh
+++ b/src/lib/errorhandler.hh
@@ -1,0 +1,31 @@
+#ifndef ERROR_LOG
+#define ERROR_LOG
+#pragma once
+
+#include <string>
+#include <vector>
+
+#include "token.hh"
+
+// An entry in the error log
+class ErrorLogEntry {
+  public:
+    size_t line_num;
+    std::string message;
+    
+    ErrorLogEntry (
+      size_t line_num,
+      std::string message
+    ) : line_num(line_num), message(message) {}
+};
+
+// Error handler class
+// This will handle all the errors that the compiler comes across
+class ErrorHandler {
+  public:
+    std::vector <ErrorLogEntry> error_log;
+    void print_errors();
+    void new_error(size_t line_num, std::string message);
+};
+
+#endif /* ERROR_LOG */

--- a/src/lib/parser.cc
+++ b/src/lib/parser.cc
@@ -2,6 +2,7 @@
 #include "ast.hh"
 #include "token.hh"
 #include "lexer.hh"
+#include "errorhandler.hh"
 
 #include <string>
 #include <cstdlib>
@@ -105,7 +106,10 @@ Parser::parse_let_statement() {
     if (this->peek_token.type == TOK_EQUALS) {
       // read identifier then an equals -> assume they forgot to put type spec
       // because they forgot it, we have one less token, and we are already at the variable identifier
-      printf("parse_let: error on line %d: missing type specifier for '%s'\n", type_spec.line_num, type_spec.literal.c_str());
+      char msg[100];
+      sprintf(msg, "parse_let: error on line %d: missing type specifier for '%s'\n", type_spec.line_num, type_spec.literal.c_str());
+      std::string errmsg = msg;
+      this->error_handler->new_error(type_spec.line_num, errmsg);
       ident_tok = type_spec;
 
     } else if (this->peek_token.type == TOK_IDENT) {

--- a/src/lib/parser.hh
+++ b/src/lib/parser.hh
@@ -11,6 +11,7 @@
 
 #include "lexer.hh"
 #include "ast.hh"
+#include "errorhandler.hh"
 #include <string>
 #include <map>
 
@@ -22,6 +23,7 @@ public:
   Parser(std::vector<token_t> token_stream);  // constructor -- uses string parameter to initialize a lexer
   ~Parser();                  // destructor -- deletes the lexer that it created
 
+  ErrorHandler *error_handler; // error hander given to the parser by the compiler -- DO NOT FREE: THIS SHOULD BE GIVEN BACK TO THE COMPILER WHEN WE ARE DONE
   void next_token();          // eats current token and advances the peek and current tokens
   int get_token_precedence(); // gets the precedence for the current token
   bool has_entry;             // true if there is an entry point false otherwise

--- a/tests/test0.tb
+++ b/tests/test0.tb
@@ -1,4 +1,5 @@
 define int main() {
-  let int x = add(1+1, y) + 14;
+  let inty x = add(1+1, y) + 14;
+  let y = 0;
   return x;
 }


### PR DESCRIPTION
There is an ErrorHandler class, and that contains an error log. This log only contains a field for a vector of ErrorLogEntry's, but this can be expanded upon if necessary later.

The parser can also now use this error handler to print out its errors. For now this is only done once for a test, but this should later be used to emit all errors that it comes across.