### PR TITLE
CodeBlock has member field for a symbol table

### DIFF
--- a/src/lib/ast.hh
+++ b/src/lib/ast.hh
@@ -9,6 +9,7 @@
 #define AST_
 
 #include "token.hh"
+#include "symboltable.hh"
 #include <vector>
 #include <string>
 #include <memory>
@@ -115,7 +116,8 @@ class FloatExpr : public Expression {
 // }
 class CodeBlock : public Statement {
   public:
-    std::vector <std::unique_ptr<Statement> > body;
+    std::vector <std::unique_ptr<Statement> > body; // the body of code of this scope
+    std::unique_ptr<SymbolTable> symbol_table;      // the symbol table of identifiers for this code block's scope
     // add a field for an inner scope
 
     CodeBlock(


### PR DESCRIPTION
Added a field of a std::unique_ptr for a symbol_table in the CodeBlock AST node class.