### PR TITLE
Code Block parent nodes

### DIFF
--- a/src/lib/ast.hh
+++ b/src/lib/ast.hh
@@ -226,15 +226,15 @@ class ReturnStmt : public Statement {
 class Conditional : public Statement {
   public:
     token_t token;
-    std::unique_ptr<Statement> consequence;                   // body of if statement
+    std::shared_ptr<Statement> consequence;                   // body of if statement
     std::unique_ptr<Expression> condition;                // the condition to evaluate
-    std::unique_ptr<Statement> alternative;             // the conditional to evaluate if the condition is not true -- this is how we do else-if
+    std::shared_ptr<Statement> alternative;             // the conditional to evaluate if the condition is not true -- this is how we do else-if
 
     Conditional(
       token_t token,
-      std::unique_ptr<Statement> consequence,
+      std::shared_ptr<Statement> consequence,
       std::unique_ptr<Expression> condition,
-      std::unique_ptr<Statement> alternative
+      std::shared_ptr<Statement> alternative
     ) : token(token), 
         consequence(std::move(consequence)),
         condition(std::move(condition)),
@@ -251,12 +251,12 @@ class WhileLoop : public Statement {
     token_t token;
     std::unique_ptr<Expression> condition;
     // std::vector<std::unique_ptr<Statement> > loop_body;
-    std::unique_ptr<Statement> loop_body;
+    std::shared_ptr<Statement> loop_body;
 
     WhileLoop(
       token_t token,
       std::unique_ptr<Expression> condition,
-      std::unique_ptr<Statement> loop_body
+      std::shared_ptr<Statement> loop_body
     ) : token(token), 
         condition(std::move(condition)),
         loop_body(std::move(loop_body))
@@ -275,14 +275,14 @@ class ForLoop : public Statement {
     std::unique_ptr<Statement> initialization; // the initialization statement in the for loop
     std::unique_ptr<Expression> condition;      // the condition that the loop runs until fulfilled
     std::unique_ptr<Expression> action;         // the action that gets taken at the end of each iteration
-    std::unique_ptr<Statement> loop_body;      // the body of the for loop
+    std::shared_ptr<Statement> loop_body;      // the body of the for loop
 
     ForLoop(
       token_t token,
       std::unique_ptr<Statement> initialization,
       std::unique_ptr<Expression> condition,
       std::unique_ptr<Expression> action,
-      std::unique_ptr<Statement> loop_body
+      std::shared_ptr<Statement> loop_body
     ) : token(token) , initialization(std::move(initialization)), condition(std::move(condition)) , action(std::move(action)), loop_body(std::move(loop_body)) {}
     void print() override;
 };
@@ -305,12 +305,12 @@ class Prototype {
 class FunctionDecl : public Statement {
   public:
     bool is_entry;                                 // true if it is the entry point to the program false otherwise
-    std::unique_ptr<Statement> func_body;          // a CodeBlock that contains the body of the function
+    std::shared_ptr<Statement> func_body;          // a CodeBlock that contains the body of the function
     std::unique_ptr<Prototype> prototype;          // the prototype of the function
 
     FunctionDecl(
       bool is_entry,
-      std::unique_ptr<Statement> func_body,
+      std::shared_ptr<Statement> func_body,
       std::unique_ptr<Prototype> prototype
     ) : is_entry(is_entry), func_body(std::move(func_body)), prototype(std::move(prototype)) {}
     void print() override;

--- a/src/lib/ast.hh
+++ b/src/lib/ast.hh
@@ -118,6 +118,7 @@ class CodeBlock : public Statement {
   public:
     std::vector <std::unique_ptr<Statement> > body; // the body of code of this scope
     std::unique_ptr<SymbolTable> symbol_table;      // the symbol table of identifiers for this code block's scope
+    std::shared_ptr<Statement> parent_scope;        // the parent scope of this code block. Can be function or global scope
     // add a field for an inner scope
 
     CodeBlock(

--- a/src/lib/parser.cc
+++ b/src/lib/parser.cc
@@ -460,7 +460,11 @@ Parser::parse_code_block() {
   printf("parse_code_block: should be eating '}'\n");
   this->next_token();
 
-  return std::make_shared<CodeBlock>(std::move(body));
+  auto code_block = std::make_shared<CodeBlock>(std::move(body));
+  auto symbol_table = std::make_unique<SymbolTable>();
+  code_block->symbol_table = std::move(symbol_table);
+
+  return code_block; 
 }
 
 // Parse a for loop statement

--- a/src/lib/parser.cc
+++ b/src/lib/parser.cc
@@ -407,7 +407,7 @@ Parser::parse_function_defn() {
 }
 
 // Parse a code block
-std::unique_ptr<Statement>
+std::shared_ptr<Statement>
 Parser::parse_code_block() {
   token_t tok = this->current_token;
   if (tok.type != TOK_LBRACE) {
@@ -460,7 +460,7 @@ Parser::parse_code_block() {
   printf("parse_code_block: should be eating '}'\n");
   this->next_token();
 
-  return std::make_unique<CodeBlock>(std::move(body));
+  return std::make_shared<CodeBlock>(std::move(body));
 }
 
 // Parse a for loop statement

--- a/src/lib/parser.hh
+++ b/src/lib/parser.hh
@@ -33,7 +33,7 @@ public:
 
   // Parsing functions
   std::unique_ptr<Program> parse_program();                         // parse the top level program
-  std::unique_ptr<Statement> parse_code_block();                    // parse a block of code
+  std::shared_ptr<Statement> parse_code_block();                    // parse a block of code
   std::unique_ptr<Statement> parse_let_statement();                 // parse let statements
   std::unique_ptr<Statement> parse_return_statement();              // parse return statements
   std::unique_ptr<Statement> parse_else_statement();                // parse else clauses and else-if clauses


### PR DESCRIPTION
Code block nodes now contain a parent node for their parent scope. Currently the parser does not support inner scopes, so the only parent scope at the moment is the global scope.