### PR TITLE
Check for wrong number of args in a function call

### DIFF
--- a/src/lib/ast.cc
+++ b/src/lib/ast.cc
@@ -243,6 +243,7 @@ FunctionDecl::_get_st_entry() {
                                                             1     // decl line -- change when we read this when parsing
                                                         );
 
+    symbol_table_entry->num_args = this->prototype->params.size();
     return symbol_table_entry;
 }
 
@@ -279,6 +280,16 @@ FunctionCallExpr::_get_type() {
 // [FUTURE: PERFORM SYNTAX CHECK ON FUNCTION CALL]
 void
 FunctionCallExpr::_syntax_analysis() {
+    std::shared_ptr<SymbolTableEntry> ste = this->parent->_scope_lookup(this->name);
+    if (!ste) {
+        printf("FUNC CALL SYN NULL STE\n");
+        return;
+    }
+    if (ste->num_args != this->args.size()) {
+        printf("Error: incorrect number of arguments in function call. Expected %lu\n", ste->num_args);
+    } else {
+        printf("ARG MATCH\n");
+    }
     printf("func call syn\n");
 }
 

--- a/src/lib/ast.cc
+++ b/src/lib/ast.cc
@@ -286,9 +286,9 @@ FunctionCallExpr::_syntax_analysis() {
         return;
     }
     if (ste->num_args != this->args.size()) {
-        printf("Error: incorrect number of arguments in function call. Expected %lu\n", ste->num_args);
+        printf("Error: incorrect number of arguments in function call. Expected %lu got %lu\n", ste->num_args, this->args.size());
     } else {
-        printf("ARG MATCH\n");
+        printf("ARG MATCH %lu == %lu\n", ste->num_args, this->args.size());
     }
     printf("func call syn\n");
 }

--- a/src/lib/symboltable.hh
+++ b/src/lib/symboltable.hh
@@ -18,6 +18,7 @@ class SymbolTableEntry {
         uint32_t decl_line;    // line of declaration of the element
         uint32_t usage_line; // line of usage of the element
         uint64_t mem_addr;     // location in memory of the element
+        uint64_t num_args;     // number of arguments of a function 
 
         // Member functions
         SymbolTableEntry(

--- a/tests/test0.tb
+++ b/tests/test0.tb
@@ -1,12 +1,12 @@
-define int func() {
+define int func(int z) {
     return 0;
 }
 
 entry int main(int x) {
     for (let int i = 0; i < 10; i += 1;) {
-        func();
+        func(i);
 
-        let int k = func();
+        let int k = func(i+1);
     }
 
 

--- a/tests/test0.tb
+++ b/tests/test0.tb
@@ -6,7 +6,7 @@ entry int main(int x) {
     for (let int i = 0; i < 10; i += 1;) {
         func();
 
-        let int k = func2();
+        let int k = func();
     }
 
 


### PR DESCRIPTION
Check that a function call has the same number of arguments when it is called as when it is declared.